### PR TITLE
Make URL clickable in the terminal

### DIFF
--- a/whippet.php
+++ b/whippet.php
@@ -476,7 +476,7 @@ else {
   echo "Using a WordPress core at: {$options['wp-root']}\n";
 }
 
-echo "Listening on {$options['i']}:{$options['p']}\n";
+echo "Listening on http://{$options['i']}:{$options['p']}\n";
 echo "Press Ctrl-C to quit.\n";
 
 //


### PR DESCRIPTION
CMD+click on the URL will open a browser window only if a protocol is referenced.

Otherwise, here is the error message a user will get when clicking "localhost:8000" (for example):

![screenshot 2015-04-17 21 59 13](https://cloud.githubusercontent.com/assets/85783/7210831/076b8ad0-e54d-11e4-977c-a64c429203ad.png)
