### PR TITLE
Use Ubuntu Vivid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:vivid
 
 # upgrade debian packages
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
Trusty (LTS) uses PHP 5.5 which for whatever reason has an issue with using file_get_contents() on HTTPS URLs. This was causing issues with an API used by one of the projects we were working on.