### PR TITLE
Don't mess up wp-config.php when running from wp-content

### DIFF
--- a/whippet.php
+++ b/whippet.php
@@ -410,7 +410,7 @@ require_once('{$dir}/lib/load_whippet.php');
 EOT;
 
 // Get the config
-if(WPS_LOCATION == 'root') {
+if(WPS_LOCATION == 'root'||(WPS_LOCATION == 'wp-content' && file_exists($options['wp-root'] . "/wp-config.php"))) {
   if(file_exists($options['wp-root'] . "/wp-config.php")) {
     $options['wp-config'] = $options['wp-root'] . "/wp-config.php";
   }


### PR DESCRIPTION
This is just a quick fix for when whippet-server is ran from within wp-content (when there is a wordpress core in parent directory), the wp-config.php gets injected with the code as if it's using the generated whippet-wp-config.php file.

I think it was my last pull request that introduced this, which looking back at it now has made the code a little unmanageable.

I'm going to try sort it out so that there are only 2 possible states:
1. We are in a wp-content directory with no wordpress core in parent directory
2. We are in a Wordpress root

Also, I'll make an attempt at being able to run whippet-server from anywhere within the wordpress directory (And changing the working directory to match the relevant state as above).
