### PR TITLE
Replacing calls to Colours::fg('white') with an off() function

### DIFF
--- a/lib/colours.class.php
+++ b/lib/colours.class.php
@@ -33,6 +33,10 @@ class Colours {
     'light_grey' => '47',
   );
 
+  static public function off() {
+    return "\033[m";
+  }
+
   static public function fg($colour) {
     return "\033[" . Colours::$foreground[$colour] . "m";
   }

--- a/lib/launcher-functions.php
+++ b/lib/launcher-functions.php
@@ -6,7 +6,7 @@
 function die_with_error($error, $help = '') {
   echo Colours::fg('red');
   echo "Error: {$error}\n";
-  echo Colours::fg('white');
+  echo Colours::off();
 
   if(!empty($help)) {
     echo "\n{$help}\n";

--- a/lib/whippet.class.php
+++ b/lib/whippet.class.php
@@ -50,7 +50,7 @@ class Whippet {
     $this->cb_cache = new CallbackCache($this->options);
 
     if(!$this->cb_cache->load($this->options['cb-cache'])) {
-      $this->message(Colours::fg('brown') . "Warning: " . Colours::fg('white') . "Unable to load or create callback cache file {$this->options['cb-cache']}. Displaying hook data will be slow.");
+      $this->message(Colours::fg('brown') . "Warning: " . Colours::off() . "Unable to load or create callback cache file {$this->options['cb-cache']}. Displaying hook data will be slow.");
     }
   }
 
@@ -93,7 +93,7 @@ class Whippet {
         $this->message(
           Colours::fg('bold_red') .
           "Error: " .
-          Colours::fg('white') .
+          Colours::off() .
           "Unable to write options file. This is a serious error. You should probably give up and report a bug.");
       }
     }
@@ -102,7 +102,7 @@ class Whippet {
       $this->message(
         Colours::fg('bold_red') .
         "Error: " .
-        Colours::fg('white') .
+        Colours::off() .
         "Unable to locate options on stdin or on the disk. This is a serious error. You should probably give up and report a bug.");
     }
 
@@ -135,8 +135,8 @@ class Whippet {
 
     file_put_contents("php://stdout",
       Colours::fg('dark_grey') . "[" . date("Y-m-d H:i:s") . "]" .
-      Colours::fg('white') . " {$string}" .
-      Colours::fg('white') . "\n" );
+      Colours::off() . " {$string}" .
+      Colours::off() . "\n" );
   }
 
 
@@ -153,7 +153,7 @@ class Whippet {
    * Prints basic information about the request being processed
    */
   public function request_message() {
-    $this->message("\nStarted {$_SERVER['REQUEST_METHOD']} " . Colours::fg('green') . "\"{$_SERVER['REQUEST_URI']}\"" . Colours::fg('white') . " for {$_SERVER['REMOTE_ADDR']}");
+    $this->message("\nStarted {$_SERVER['REQUEST_METHOD']} " . Colours::fg('green') . "\"{$_SERVER['REQUEST_URI']}\"" . Colours::off() . " for {$_SERVER['REMOTE_ADDR']}");
   }
 
   /**
@@ -205,7 +205,7 @@ class Whippet {
       " in " .
       $file .
       " at line {$line}" .
-      Colours::fg("white")
+      Colours::off()
     );
 
     // Show a notification, if we've got libnotify
@@ -455,11 +455,11 @@ class Whippet {
       $file = str_replace($this->options['wp-root'] . "/wp-content/", '', $in_func['file']);
 
       $message .=
-        Colours::fg("white") ."Triggered by function " .
+        Colours::off() ."Triggered by function " .
         Colours::fg("blue") . "{$in_func['function']}" .
-        Colours::fg("white") . " called from " .
+        Colours::off() . " called from " .
         Colours::fg("brown") . $file .
-        Colours::fg("white") . " at line {$in_func['line']}:";
+        Colours::off() . " at line {$in_func['line']}:";
     }
     else {
 
@@ -526,7 +526,7 @@ class Whippet {
     $this->message(
       Colours::fg('yellow') .
       "Template load: " .
-      Colours::fg('white') .
+      Colours::off() .
       "wanted {$want_template}, got {$got_template} (" . str_replace($this->options['wp-root'] . "/wp-content/", '', $template) . ")"
     );
 
@@ -639,7 +639,7 @@ class Whippet {
           continue;
         }
 
-        $callback_message =  "\t{$priority}: " . Colours::fg('cyan') . $function .  Colours::fg('white');
+        $callback_message =  "\t{$priority}: " . Colours::fg('cyan') . $function .  Colours::off();
         $callback_data = $this->cb_cache->lookup($function);
 
         if(!$callback_data) {
@@ -670,7 +670,7 @@ class Whippet {
             $callback_data['file'] = str_replace($this->options['wp-content'], '', $callback_data['file']);
           }
 
-          $callback_message .= " in " . Colours::fg("brown") . str_replace($this->options['wp-root'] . "/wp-content/", '', $callback_data['file']) . Colours::fg("white") . " at line {$callback_data['line']}";
+          $callback_message .= " in " . Colours::fg("brown") . str_replace($this->options['wp-root'] . "/wp-content/", '', $callback_data['file']) . Colours::off() . " at line {$callback_data['line']}";
         }
         else {
           $callback_message .= " (couldn't find this function's definition)";
@@ -724,22 +724,22 @@ class Whippet {
 
     $message =
       Colours::fg('bold_cyan') . "Hook triggered: " .
-      Colours::fg('white') . "{$type} " .
+      Colours::off() . "{$type} " .
       Colours::fg('cyan') . "{$hook}" .
-      Colours::fg('white') . " called from function " .
+      Colours::off() . " called from function " .
       Colours::fg('cyan') . "{$caller['function']}";
 
     if(!empty($caller['file'])) {
       $message .=
-        Colours::fg("white") . " in " .
+        Colours::off() . " in " .
         Colours::fg('brown') . str_replace($this->options['wp-root'], '', $caller['file']);
     }
 
     if(!empty($caller['line'])) {
-      $message .= Colours::fg("white") . " at line {$caller['line']}";
+      $message .= Colours::off() . " at line {$caller['line']}";
     }
 
-    $this->message("{$message}" . Colours::fg('white'));
+    $this->message("{$message}" . Colours::off());
     foreach($callback_messages as $callback_message) {
       $this->message($callback_message);
     }

--- a/whippet.php
+++ b/whippet.php
@@ -180,7 +180,7 @@ EOT;
   }
   elseif(!file_exists($options['wp-root'] . "/whippet-wp-config.php")) {
     echo
-      Colours::fg('red') . "Error: " . Colours::fg('white') .
+      Colours::fg('red') . "Error: " . Colours::off() .
       "Couldn't find a configuration file at " . $options['wp-root'] . "/whippet-wp-config.php\n" .
       "Whippet needs this file in order to know where your database is. You can specify anything\n" .
       "there that you would normally put in wp-config.php. At a minimum, it must contain your\n" .
@@ -243,7 +243,7 @@ if(WPS_LOCATION == 'root' && !file_exists($options['wp-root'] . '/wp-config.php'
 // If location is wp-content, check that we have some core files, and download them if we don't
 if(WPS_LOCATION == 'wp-content' && !file_exists("{$options['wordpresses']}/{$options['wp-version']}") && !file_exists($options['wp-root'] . '/../wp-config.php')) {
   echo
-    Colours::fg('red') . "Error: " . Colours::fg('white') .
+    Colours::fg('red') . "Error: " . Colours::off() .
     "Unable to find the specified WordPress core in your wordpresses directory ({$options['wordpresses']})\n",
     "To run a site from its wp-content folder without it being in a WordPress installation, you need to set up your\n" .
     "core WordPress files in the directory above. Whippet can set this up for you automatically.\n\n";
@@ -335,7 +335,7 @@ function signal_handler($signal) {
     else {
       if(WPS_LOCATION == 'root') {
         Whippet::message(
-          Colours::fg('red') . "Error: " . Colours::fg('white') . "Unable to find wp-config backup file; could not restore original configuration",
+          Colours::fg('red') . "Error: " . Colours::off() . "Unable to find wp-config backup file; could not restore original configuration",
           "Your wp-config file should have been backed up at " . dirname($options['wp-config']). "/wp-config-original.whippet.bak, but\n" .
           "it is missing or unreadable. You should edit your wp-config.php by hand to remove the\n" .
           "Whippet sections.\n");
@@ -474,7 +474,7 @@ echo "\nNote: Whippet is Alpha software. We're sure it still has problems that n
 echo "fixed, and we know the install process is a bit labourious. Please do let us know\n";
 echo "how you get on, or open an issue on GitHub if you have problems. Thanks!\n\n";
 
-echo Colours::fg('white');
+echo Colours::off();
 echo "Written and maintained by dxw. Visit http://whippet.labs.dxw.com for more information.\n";
 
 if(WPS_LOCATION == 'root') {
@@ -519,7 +519,7 @@ while(!feof($handle)) {
 
   // Other stuff that comes out of PHP -S (only seen invalid request warnings so far)
   if(preg_match('/\[\w\w\w \w\w\w [\d\s:]+\] (.+)$/', $line, $matches)) {
-    Whippet::message(Colours::fg('blue') . "Server: " . Colours::fg('white') . $matches[1]);
+    Whippet::message(Colours::fg('blue') . "Server: " . Colours::off() . $matches[1]);
     continue;
   }
 


### PR DESCRIPTION
This is designed to make it so colours don't spill out of the script and cause irritation to users. Also, because the white colour is often hard to read against a white background (such as the stock OS X Terminal.app UI which uses a light grey).

See screenshots below.

Before

![screen shot 2016-06-09 at 15 49 06](https://cloud.githubusercontent.com/assets/175/15934136/4cbbc22e-2e5a-11e6-8e25-b41d47aa3f8c.png)

After

![screen shot 2016-06-09 at 15 50 09](https://cloud.githubusercontent.com/assets/175/15934140/5022dce0-2e5a-11e6-8232-dcee806cc309.png)
