### PR TITLE
Normalise path component of request URI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "dxw/whippet-server",
     "require": {
-        "mjackson/optionparser": "dev-master"
+        "mjackson/optionparser": "dev-master",
+        "sabre/uri": "^1.1"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "af264fc25a5822f0b03a953de531b164",
+    "hash": "82fb30eb10cdc428f85419bfd34c97bb",
+    "content-hash": "3ef7e150cc15509d2cc640a94f1498e2",
     "packages": [
         {
             "name": "mjackson/optionparser",
@@ -28,6 +29,57 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "time": "2015-03-17 16:57:12"
+        },
+        {
+            "name": "sabre/uri",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fruux/sabre-uri.git",
+                "reference": "9012116434d84ef6e5e37a89dfdbfbe2204a8704"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fruux/sabre-uri/zipball/9012116434d84ef6e5e37a89dfdbfbe2204a8704",
+                "reference": "9012116434d84ef6e5e37a89dfdbfbe2204a8704",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.7"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*",
+                "sabre/cs": "~0.0.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/functions.php"
+                ],
+                "psr-4": {
+                    "Sabre\\Uri\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Functions for making sense out of URIs.",
+            "homepage": "http://sabre.io/uri/",
+            "keywords": [
+                "rfc3986",
+                "uri",
+                "url"
+            ],
+            "time": "2016-03-08 02:29:27"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
This was previously allowing malicious requests like the following:
`GET /../../../etc/passwd HTTP/1.1`.

Resolves: https://dxw.zendesk.com/agent/tickets/5659
